### PR TITLE
Fix "strpos(): Empty needle" w/ empty prefix

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -191,7 +191,9 @@ class AzureBlobStorageAdapter extends AbstractAdapter
         $result = [];
         $response =  $this->client->listBlobs($this->container, $options);
         foreach ($response->getBlobs() as $blob) {
-            if (strpos($name = $blob->getName(), $location) === 0) {
+            $name = $blob->getName();
+
+            if ($location === '' || strpos($name, $location) === 0) {
                 $result[] = $this->normalizeBlobProperties($name, $blob->getProperties());
             }
         }


### PR DESCRIPTION
PHP Warning:  strpos(): Empty needle in /home/maetthu/git/emgag/flysystem-azure-testing/vendor/league/flysystem-azure-blog-storage/src/AzureBlobStorageAdapter.php on line 194
PHP Stack trace:
PHP   1. {main}() /home/maetthu/git/emgag/flysystem-azure-testing/test.php:0
PHP   2. League\Flysystem\Filesystem->listContents() /home/maetthu/git/emgag/flysystem-azure-testing/test.php:19
PHP   3. League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter->listContents() /home/maetthu/git/emgag/flysystem-azure-testing/vendor/league/flysystem/src/Filesystem.php:271
PHP   4. strpos() /home/maetthu/git/emgag/flysystem-azure-testing/vendor/league/flysystem-azure-blog-storage/src/AzureBlobStorageAdapter.php:194